### PR TITLE
ICondition fix and optional tags

### DIFF
--- a/src/main/java/com/tterrag/registrate/builders/AbstractBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/AbstractBuilder.java
@@ -60,6 +60,9 @@ public abstract class AbstractBuilder<R, T extends R, P, S extends AbstractBuild
     /** A supplier for the entry that will discard the reference to this builder after it is resolved */
     private final LazyRegistryEntry<R, T> safeSupplier = new LazyRegistryEntry<>(this);
 
+    /** Indicates whether this entry should generate tags as optional tag */
+    private boolean isOptional = false;
+
     /**
      * Create the built entry. This method will be lazily resolved at registration time, so it is safe to bake in values from the builder.
      *
@@ -98,10 +101,25 @@ public abstract class AbstractBuilder<R, T extends R, P, S extends AbstractBuild
             setData(type, (ctx, prov) -> tagsByType.get(type).stream()
                     .map(t -> (TagKey<R>) t)
                     .map(prov::addTag)
-                    .forEach(b -> b.add(TagEntry.element(ResourceLocation.fromNamespaceAndPath(getOwner().getModid(), getName())))));
+                    .forEach(b -> b.add(asTag())));
         }
         tagsByType.putAll(type, Arrays.asList(tags));
         return (S) this;
+    }
+
+    /**
+     * Mark this entry as optional when generating tags
+     * */
+    @SuppressWarnings("unchecked")
+    public S asOptional(){
+        isOptional = true;
+        return (S) this;
+    }
+
+    protected TagEntry asTag() {
+        ResourceLocation id = ResourceLocation.fromNamespaceAndPath(getOwner().getModid(), getName());
+        if (isOptional) return TagEntry.optionalElement(id);
+        return TagEntry.element(id);
     }
 
     /**

--- a/src/main/java/com/tterrag/registrate/providers/RegistrateAdvancementProvider.java
+++ b/src/main/java/com/tterrag/registrate/providers/RegistrateAdvancementProvider.java
@@ -15,6 +15,8 @@ import net.minecraft.data.PackOutput;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.fml.LogicalSide;
+import net.neoforged.neoforge.common.conditions.ICondition;
+import net.neoforged.neoforge.common.conditions.WithConditions;
 
 import javax.annotation.Nullable;
 import java.nio.file.Path;
@@ -76,6 +78,10 @@ public class RegistrateAdvancementProvider implements RegistrateProvider, Consum
 
     @Override
     public void accept(@Nullable AdvancementHolder holder) {
+        withConditions(holder);
+    }
+
+    public void withConditions(@Nullable AdvancementHolder holder, ICondition... conditions) {
         this.registriesLookup.thenAccept((lookup) -> {
             CachedOutput cache = this.cache;
             if (cache == null) {
@@ -85,8 +91,12 @@ public class RegistrateAdvancementProvider implements RegistrateProvider, Consum
             Path path = this.packOutput.getOutputFolder();
             if (!seenAdvancements.add(holder.id())) {
                 throw new IllegalStateException("Duplicate advancement " + holder.id());
-            } else {
+            } else if (conditions.length == 0) {
                 advancementsToSave.add(DataProvider.saveStable(cache, lookup, Advancement.CODEC, holder.value(), getPath(path, holder)));
+            } else {
+                advancementsToSave.add(DataProvider.saveStable(cache, lookup, Advancement.CONDITIONAL_CODEC,
+                        Optional.of(new WithConditions<>(List.of(conditions), holder.value())),
+                        getPath(path, holder)));
             }
         });
     }

--- a/src/main/java/com/tterrag/registrate/providers/RegistrateAdvancementProvider.java
+++ b/src/main/java/com/tterrag/registrate/providers/RegistrateAdvancementProvider.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 

--- a/src/main/java/com/tterrag/registrate/providers/RegistrateAdvancementProvider.java
+++ b/src/main/java/com/tterrag/registrate/providers/RegistrateAdvancementProvider.java
@@ -79,10 +79,10 @@ public class RegistrateAdvancementProvider implements RegistrateProvider, Consum
 
     @Override
     public void accept(@Nullable AdvancementHolder holder) {
-        withConditions(holder);
+        withConditions(holder, List.of());
     }
 
-    public void withConditions(@Nullable AdvancementHolder holder, ICondition... conditions) {
+    public void withConditions(@Nullable AdvancementHolder holder, List<ICondition> conditions) {
         this.registriesLookup.thenAccept((lookup) -> {
             CachedOutput cache = this.cache;
             if (cache == null) {
@@ -92,11 +92,11 @@ public class RegistrateAdvancementProvider implements RegistrateProvider, Consum
             Path path = this.packOutput.getOutputFolder();
             if (!seenAdvancements.add(holder.id())) {
                 throw new IllegalStateException("Duplicate advancement " + holder.id());
-            } else if (conditions.length == 0) {
+            } else if (conditions.isEmpty()) {
                 advancementsToSave.add(DataProvider.saveStable(cache, lookup, Advancement.CODEC, holder.value(), getPath(path, holder)));
             } else {
                 advancementsToSave.add(DataProvider.saveStable(cache, lookup, Advancement.CONDITIONAL_CODEC,
-                        Optional.of(new WithConditions<>(List.of(conditions), holder.value())),
+                        Optional.of(new WithConditions<>(conditions, holder.value())),
                         getPath(path, holder)));
             }
         });

--- a/src/main/java/com/tterrag/registrate/providers/RegistrateRecipeProvider.java
+++ b/src/main/java/com/tterrag/registrate/providers/RegistrateRecipeProvider.java
@@ -66,7 +66,7 @@ public class RegistrateRecipeProvider extends RecipeProvider implements Registra
         if (callback == null) {
             throw new IllegalStateException("Cannot accept recipes outside of a call to registerRecipes");
         }
-        callback.accept(id, recipe, advancement);
+        callback.accept(id, recipe, advancement, conditions);
     }
 
     @Override


### PR DESCRIPTION
1. Allow Advancements and Recipes to generate ICondition
2. Allow Builders to generate tags as optional tag, in case those entries are crossover contents that only load when certain mods are present.